### PR TITLE
NONPR-1645 Mitigate MalformedInputException

### DIFF
--- a/src/main/scala/uk/gov/hmrc/nonrep/pdfs/server/ServiceConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/nonrep/pdfs/server/ServiceConfig.scala
@@ -6,7 +6,7 @@ import java.net.URI
 import com.typesafe.config.ConfigFactory
 import uk.gov.hmrc.nonrep.pdfs.model.DocumentTemplate
 
-import scala.io.Source
+import scala.io.{Codec, Source}
 import scala.jdk.CollectionConverters._
 
 class ServiceConfig(val defaultPort: Int = 8000) {
@@ -41,7 +41,7 @@ class ServiceConfig(val defaultPort: Int = 8000) {
   val signaturesServicePort = signaturesServiceUri.getPort
 
   //this method can be changed when JSON schema is kept on k8s config map
-  private[pdfs] def loadJsonTemplate(name: JSONSchema) = Source.fromResource(name).mkString
+  private[pdfs] def loadJsonTemplate(name: JSONSchema) = Source.fromResource(name)(Codec.UTF8).mkString
 
   override def toString =
     s"""


### PR DESCRIPTION
For some reason MalformedInputException is thrown on aws/codebuild/standard:3.0 image when building assembly
I hope this'll fix the issue