### PR TITLE
NONPR-1832 Update iText DITO SDK to v1.5.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val logbackVersion = "1.2.3"
 val metricsVersion = "1.3.0"
 val prometheusClientsVersion = "0.9.0"
 val circeVersion = "0.13.0"
-val ditoSdkVersion = "1.5.4"
+val ditoSdkVersion = "1.5.6"
 
 val projectName = "generate-pdf"
 

--- a/dito/editor/Dockerfile
+++ b/dito/editor/Dockerfile
@@ -1,4 +1,4 @@
 FROM java:8
 WORKDIR /
 ADD app /app
-CMD ["java", "-jar", "/app/editor-server-1.5.4.jar", "server", "/app/config.yml"]
+CMD ["java", "-jar", "/app/editor-server-1.5.6.jar", "server", "/app/config.yml"]


### PR DESCRIPTION
Can confirm the DITO editor container is updated to use v1.5.6 and works as expected. As for the PDF service, I've bumped the dependency to v.1.5.6 but need help/review to confirm this is all that's needed.